### PR TITLE
Add support for all photo sizes

### DIFF
--- a/lib/fleakr/objects/photo.rb
+++ b/lib/fleakr/objects/photo.rb
@@ -33,7 +33,7 @@ module Fleakr
     class Photo
 
       # Available sizes for this photo
-      SIZES = [:square, :thumbnail, :small, :medium, :large, :original]
+      SIZES = [:square, :large_square, :thumbnail, :small, :small_320, :medium, :medium_640, :medium_800, :large, :large_1600, :large_2048, :original]
 
       include Fleakr::Support::Object
       extend Forwardable
@@ -154,7 +154,7 @@ module Fleakr
       private
       def images_by_size
         image_sizes = SIZES.inject({}) {|l,o| l.merge(o => nil)}
-        images.inject(image_sizes) {|l,o| l.merge!(o.size.downcase.to_sym => o) }
+        images.inject(image_sizes) {|l,o| l.merge!(o.size.downcase.gsub(" ", "_").to_sym => o) }
       end
 
     end

--- a/test/fixtures/photos.getSizes.xml
+++ b/test/fixtures/photos.getSizes.xml
@@ -5,6 +5,7 @@
   	<size label="Thumbnail" width="100" height="67" source="http://farm4.static.flickr.com/3093/2409912100_71e14ed08a_t.jpg" url="http://www.flickr.com/photos/the_decapitator/2409912100/sizes/t/" media="photo" />
   	<size label="Small" width="240" height="160" source="http://farm4.static.flickr.com/3093/2409912100_71e14ed08a_m.jpg" url="http://www.flickr.com/photos/the_decapitator/2409912100/sizes/s/" media="photo" />
   	<size label="Medium" width="500" height="334" source="http://farm4.static.flickr.com/3093/2409912100_71e14ed08a.jpg" url="http://www.flickr.com/photos/the_decapitator/2409912100/sizes/m/" media="photo" />
+    <size label="Large 1600" width="1599" height="1600" source="http://farm6.staticflickr.com/5032/2409912100_71e14ed08a_h.jpg" url="http://www.flickr.com/photos/the_decapitator/2409912100/sizes/h/" media="photo" />
   	<size label="Original" width="700" height="467" source="http://farm4.static.flickr.com/3093/2409912100_3305c4a108_o.jpg" url="http://www.flickr.com/photos/the_decapitator/2409912100/sizes/o/" media="photo" />
   </sizes>
 </rsp>

--- a/test/unit/fleakr/objects/photo_test.rb
+++ b/test/unit/fleakr/objects/photo_test.rb
@@ -185,17 +185,23 @@ module Fleakr::Objects
         should "have a collection of images by size" do
           photo = Photo.new
 
-          small_image, large_image = [stub(:size => 'Small'), stub(:size => 'Large')]
+          small_image, large_image, large_1600_image = [stub(:size => 'Small'), stub(:size => 'Large'), stub(:size => 'Large 1600')]
 
-          photo.stubs(:images).returns([small_image, large_image])
+          photo.stubs(:images).returns([small_image, large_image, large_1600_image])
 
           expected = {
-            :square    => nil,
-            :thumbnail => nil,
-            :small     => small_image,
-            :medium    => nil,
-            :large     => large_image,
-            :original  => nil
+            :square       => nil,
+            :large_square => nil,
+            :thumbnail    => nil,
+            :small        => small_image,
+            :small_320    => nil,
+            :medium       => nil,
+            :medium_640   => nil,
+            :medium_800   => nil,
+            :large        => large_image,
+            :large_1600   => large_1600_image,
+            :large_2048   => nil,
+            :original     => nil
           }
 
           photo.send(:images_by_size).should == expected


### PR DESCRIPTION
Flickr have added more photo sizes to their api: large square, small 320, medium 640, medium 800, large 1600, large 2048
